### PR TITLE
Fix flooding Log/Debug tab with errormessages when Host ist not reachable

### DIFF
--- a/eiscp-controller.js
+++ b/eiscp-controller.js
@@ -37,9 +37,6 @@ module.exports = function (RED) {
                 }
                 node.log('configuring to EISCP device at ' + config.host + ':' + config.port + ' model[' + config.model + ']');
                 node.eiscpjsconn = eiscp;
-                node.eiscpjsconn.on('error', function (err) {
-                    node.error('Error: ' + err.toString());
-                });
                 node.eiscpjsconn.connect({
                     host: config.host,
                     model: config.model,

--- a/eiscp-in.js
+++ b/eiscp-in.js
@@ -43,6 +43,11 @@ module.exports = function (RED) {
         function nodeStatusDisconnected() {
             node.status({fill: "red", shape: "dot", text: "disconnected"});
         }
+        
+        function nodeStatusDisconnectedWithError(error) {
+            var statusText = "disconnected (" + error.code + ")";
+            node.status({fill: "red", shape: "dot", text: statusText});
+        }
 
         node.receiveData = function (data) {
             node.log('eiscp event data[' + data.toString('hex') + ']');
@@ -70,6 +75,9 @@ module.exports = function (RED) {
             node.connection.on('connect', nodeStatusConnected);
             node.connection.removeListener('close', nodeStatusDisconnected);
             node.connection.on('close', nodeStatusDisconnected);
+            node.connection.on('error', function (err) {
+                    nodeStatusDisconnectedWithError(err);
+            });
         });
     }
 

--- a/eiscp-out.js
+++ b/eiscp-out.js
@@ -67,6 +67,11 @@ module.exports = function (RED) {
         function nodeStatusConnecting() {
             node.status({fill: "green", shape: "ring", text: "connecting"});
         }
+        
+        function nodeStatusDisconnectedWithError(error) {
+            var statusText = "disconnected (" + error.code + ")";
+            node.status({fill: "red", shape: "dot", text: statusText});
+        }
 
         this.send = function (data, sendRaw, callback) {
             node.log('send data[' + data + ']');
@@ -95,6 +100,9 @@ module.exports = function (RED) {
                 connection.on('connect', nodeStatusConnected);
                 connection.removeListener('close', nodeStatusDisconnected);
                 connection.on('close', nodeStatusDisconnected);
+                connection.on('error', function (err) {
+                    nodeStatusDisconnectedWithError(err);
+                });
 
                 try {
                     node.log("send:  " + JSON.stringify(data));


### PR DESCRIPTION
Adressing Issues #12 #9 

Connection state is visible from the ui (indicated by the red dot on the node).
I extended the message besides the red dot to contain the error message.

Therefore there is no reason anymore to flood the logs with the connection errors.

Alternatively one could of course throw the errors on the -in and -out nodes, to make them catchable. But I think disconnected receivers are more like a norm and it is to be expected that one could not always connect to them